### PR TITLE
replace remote method 'createChildIssue' with 'createIssueWithParent'

### DIFF
--- a/src/Jira/Request/IssueRequest.php
+++ b/src/Jira/Request/IssueRequest.php
@@ -120,7 +120,7 @@ class IssueRequest extends JiraRequest
     {
         // We cannot use IssueRequest::call() since the issue key is passed as
         // the last argument of the RPC call.
-        $method = 'createChildIssue';
+        $method = 'createIssueWithParent';
         if ($this->_uniqueKey) {
             return $this->_jiraClient->call($method, $issue, $this->_uniqueKey);
         } else {


### PR DESCRIPTION
Hi,

just noticed child issue creation does not work.
Changing the remote method to 'createIssueWithParent' works like a charm.

All the best,
Peter

PS: tested with JIRA v6.4.2
PPS: did not rename the method itself because of BC break...
